### PR TITLE
Fix miscalculation for ATOP_SIZE_MB

### DIFF
--- a/templates/usr/local/bin/fix_atop.sh
+++ b/templates/usr/local/bin/fix_atop.sh
@@ -42,7 +42,7 @@ done
 #Filesystem      Size  Used Avail Use% Mounted on
 #tmpfs           396M  3.6M  392M   1% /run
 USED_SPACE=$(df -h /run/ | tr -s ' ' | tail -1 | cut -d ' ' -f5 | tr -d '%')
-ATOP_SIZE_MB=$(du -sh $LOCATION  | awk '{print $1}' | cut -d '.' -f1)
+ATOP_SIZE_MB=$(du -sH $LOCATION  | awk '{print $1 / 1024}' | cut -d '.' -f1)
 
 [[ $VERBOSE ]] && echo "Used space [$USED_SPACE], atop size [$ATOP_SIZE_MB]"
 


### PR DESCRIPTION
Some examples.

```
$ echo > /tmp/test.txt
$ du -sh /tmp/test.txt | awk '{print $1}' | cut -d '.' -f1
4
$ du -sH /tmp/test.txt | awk '{print $1 / 1024}' | cut -d '.' -f1
0
```

```
$ dd if=/dev/urandom of=/tmp/test.bin bs=2000 count=10 iflag=fullblock
$ du -sh /tmp/test.bin | awk '{print $1}' | cut -d '.' -f1            
20K
$ du -sH /tmp/test.bin | awk '{print $1 / 1024}' | cut -d '.' -f1    
0
```